### PR TITLE
Add method to change lat/lng to precision 4 decimal points

### DIFF
--- a/backend/src/fun_forecast_backend/weather/weather.py
+++ b/backend/src/fun_forecast_backend/weather/weather.py
@@ -3,7 +3,7 @@ from typing import List
 
 import requests
 from requests import Response
-from decimal import *
+from decimal import Decimal
 
 import dacite
 

--- a/backend/src/fun_forecast_backend/weather/weather.py
+++ b/backend/src/fun_forecast_backend/weather/weather.py
@@ -3,6 +3,7 @@ from typing import List
 
 import requests
 from requests import Response
+from decimal import *
 
 import dacite
 
@@ -24,8 +25,16 @@ def hourly_forecast_for_coords(lat: float, long: float) -> List[HourData]:
     return hours
 
 
+def convert_to_point_coord(coord:float) -> str:
+    precise = Decimal(coord).quantize(Decimal('.0001'))
+    logger.debug(f"converted coord {coord} to precise {precise}")
+    return str(precise)
+
+
 def point_from_coords(lat: float, long: float) -> WeatherApiPoint:
-    url = f"https://api.weather.gov/points/{lat},{long}"
+    preciseLat = convert_to_point_coord(lat)
+    preciseLong = convert_to_point_coord(long)
+    url = f"https://api.weather.gov/points/{preciseLat},{preciseLong}"
     logger.debug(f"Fetching data from: {url}")
 
     r: Response = requests.get(url)


### PR DESCRIPTION
The api.weather.gov/points endpoint expects lat and long to have a precision of 4 decimal points. This ensures that we send correctly-formatted coords values no matter what the API might receive from the client.